### PR TITLE
Report views structure

### DIFF
--- a/admin/Gruntfile.js
+++ b/admin/Gruntfile.js
@@ -32,18 +32,18 @@ module.exports = function (grunt) {
                 tasks: ['bowerInstall']
             },
             js: {
-                files: ['<%= yeoman.app %>/scripts/{,*/}*.js'],
+                files: ['<%= yeoman.app %>/scripts/**/*.js'],
                 tasks: ['newer:jshint:all'],
                 options: {
                     livereload: true
                 }
             },
             jsTest: {
-                files: ['test/spec/{,*/}*.js'],
+                files: ['test/spec/**/*.js'],
                 tasks: ['newer:jshint:test', 'karma']
             },
             compass: {
-                files: ['<%= yeoman.app %>/styles/{,*/}*.{scss,sass}'],
+                files: ['<%= yeoman.app %>/styles/**/*.{scss,sass}'],
                 tasks: ['compass:server', 'autoprefixer']
             },
             gruntfile: {
@@ -54,9 +54,9 @@ module.exports = function (grunt) {
                     livereload: '<%= connect.options.livereload %>'
                 },
                 files: [
-                    '<%= yeoman.app %>/{,*/}*.html',
-                    '.tmp/styles/{,*/}*.css',
-                    '<%= yeoman.app %>/images/{,*/}*.{png,jpg,jpeg,gif,webp,svg}'
+                    '<%= yeoman.app %>/**/*.html',
+                    '.tmp/styles/**/*.css',
+                    '<%= yeoman.app %>/images/**/*.{png,jpg,jpeg,gif,webp,svg}'
                 ]
             }
         },
@@ -103,13 +103,13 @@ module.exports = function (grunt) {
             },
             all: [
                 'Gruntfile.js',
-                '<%= yeoman.app %>/scripts/{,*/}*.js'
+                '<%= yeoman.app %>/scripts/**/*.js'
             ],
             test: {
                 options: {
                     jshintrc: 'test/.jshintrc'
                 },
-                src: ['test/spec/{,*/}*.js']
+                src: ['test/spec/**/*.js']
             }
         },
 
@@ -140,7 +140,7 @@ module.exports = function (grunt) {
                     {
                         expand: true,
                         cwd: '.tmp/styles/',
-                        src: '{,*/}*.css',
+                        src: '**/*.css',
                         dest: '.tmp/styles/'
                     }
                 ]
@@ -154,7 +154,7 @@ module.exports = function (grunt) {
                 ignorePath: '<%= yeoman.app %>/'
             },
             sass: {
-                src: ['<%= yeoman.app %>/styles/{,*/}*.{scss,sass}'],
+                src: ['<%= yeoman.app %>/styles/**/*.{scss,sass}'],
                 ignorePath: '<%= yeoman.app %>/bower_components/'
             }
         },
@@ -193,9 +193,9 @@ module.exports = function (grunt) {
             dist: {
                 files: {
                     src: [
-                        '<%= yeoman.dist %>/scripts/{,*/}*.js',
-                        '<%= yeoman.dist %>/styles/{,*/}*.css',
-                        '<%= yeoman.dist %>/images/{,*/}*.{png,jpg,jpeg,gif,webp,svg}',
+                        '<%= yeoman.dist %>/scripts/**/*.js',
+                        '<%= yeoman.dist %>/styles/**/*.css',
+                        '<%= yeoman.dist %>/images/**/*.{png,jpg,jpeg,gif,webp,svg}',
                         '<%= yeoman.dist %>/styles/fonts/*'
                     ]
                 }
@@ -223,8 +223,8 @@ module.exports = function (grunt) {
 
         // Performs rewrites based on rev and the useminPrepare configuration
         usemin: {
-            html: ['<%= yeoman.dist %>/{,*/}*.html'],
-            css: ['<%= yeoman.dist %>/styles/{,*/}*.css'],
+            html: ['<%= yeoman.dist %>/**/*.html'],
+            css: ['<%= yeoman.dist %>/styles/**/*.css'],
             options: {
                 assetsDirs: ['<%= yeoman.dist %>']
             }
@@ -243,7 +243,7 @@ module.exports = function (grunt) {
                     {
                         expand: true,
                         cwd: '<%= yeoman.app %>/images',
-                        src: '{,*/}*.{png,jpg,jpeg,gif}',
+                        src: '**/*.{png,jpg,jpeg,gif}',
                         dest: '<%= yeoman.dist %>/images'
                     }
                 ]
@@ -256,7 +256,7 @@ module.exports = function (grunt) {
                     {
                         expand: true,
                         cwd: '<%= yeoman.app %>/images',
-                        src: '{,*/}*.svg',
+                        src: '**/*.svg',
                         dest: '<%= yeoman.dist %>/images'
                     }
                 ]
@@ -275,7 +275,7 @@ module.exports = function (grunt) {
                     {
                         expand: true,
                         cwd: '<%= yeoman.dist %>',
-                        src: ['*.html', 'views/{,*/}*.html'],
+                        src: ['*.html', 'views/**/*.html'],
                         dest: '<%= yeoman.dist %>'
                     }
                 ]
@@ -318,8 +318,8 @@ module.exports = function (grunt) {
                             '*.{ico,png,txt}',
                             '.htaccess',
                             '*.html',
-                            'views/{,*/}*.html',
-                            'images/{,*/}*.{webp}',
+                            'views/**/*.html',
+                            'images/**/*.{webp}',
                             'fonts/*'
                         ]
                     },
@@ -335,7 +335,7 @@ module.exports = function (grunt) {
                 expand: true,
                 cwd: '<%= yeoman.app %>/styles',
                 dest: '.tmp/styles/',
-                src: '{,*/}*.css'
+                src: '**/*.css'
             }
         },
 
@@ -361,8 +361,8 @@ module.exports = function (grunt) {
         //   dist: {
         //     files: {
         //       '<%= yeoman.dist %>/styles/main.css': [
-        //         '.tmp/styles/{,*/}*.css',
-        //         '<%= yeoman.app %>/styles/{,*/}*.css'
+        //         '.tmp/styles/**/*.css',
+        //         '<%= yeoman.app %>/styles/**/*.css'
         //       ]
         //     }
         //   }

--- a/admin/app/index.html
+++ b/admin/app/index.html
@@ -19,6 +19,7 @@
     <!-- endbuild -->
     <!-- build:css({.tmp,app}) styles/main.css -->
     <link rel="stylesheet" href="styles/main.css">
+    <link rel="stylesheet" href="bower_components/ng-prettyjson/src/ng-prettyjson.css">
     <!-- endbuild -->
 </head>
 <body ng-app="RoaveDeveloperToolsAdmin">
@@ -47,6 +48,7 @@
 <script src="bower_components/bootstrap-sass-official/vendor/assets/javascripts/bootstrap/popover.js"></script>
 <script src="bower_components/angular-resource/angular-resource.js"></script>
 <script src="bower_components/angular-route/angular-route.js"></script>
+<script src="bower_components/ng-prettyjson/src/ng-prettyjson.js"></script>
 <!-- endbower -->
 <!-- endbuild -->
 

--- a/admin/app/index.html
+++ b/admin/app/index.html
@@ -21,7 +21,7 @@
     <link rel="stylesheet" href="styles/main.css">
     <!-- endbuild -->
 </head>
-<body ng-app="adminApp">
+<body ng-app="RoaveDeveloperToolsAdmin">
 <!-- Add your site or application content here -->
 <div class="container" ng-view=""></div>
 <!--[if lt IE 9]>

--- a/admin/app/index.html
+++ b/admin/app/index.html
@@ -58,6 +58,7 @@
 <script src="scripts/controller/main.js"></script>
 <script src="scripts/controller/listInspectionsCtrl.js"></script>
 <script src="scripts/controller/inspectionCtrl.js"></script>
+<script src="scripts/controller/report/baseReportCtrl.js"></script>
 <!-- endbuild -->
 </body>
 </html>

--- a/admin/app/scripts/app.js
+++ b/admin/app/scripts/app.js
@@ -3,7 +3,8 @@
 angular
     .module('RoaveDeveloperToolsAdmin', [
         'ngResource',
-        'ngRoute'
+        'ngRoute',
+        'ngPrettyJson'
     ])
     .config(['$routeProvider', '$provide', function ($routeProvider, $provide) {
         $routeProvider
@@ -26,7 +27,8 @@ angular
         $provide.constant(
             'RDT_REPORTS',
             {
-                'base-report': 'views/report/base-report.html'
+                'base-report': 'views/report/base-report.html',
+                'config-report': 'views/report/config-report.html'
             }
         );
     }]);

--- a/admin/app/scripts/app.js
+++ b/admin/app/scripts/app.js
@@ -28,7 +28,8 @@ angular
             'RDT_REPORTS',
             {
                 'base-report': 'views/report/base-report.html',
-                'config-report': 'views/report/config-report.html'
+                'config-report': 'views/report/config-report.html',
+                'dummy-report': 'views/report/dummy-report.html',
             }
         );
     }]);

--- a/admin/app/scripts/app.js
+++ b/admin/app/scripts/app.js
@@ -1,7 +1,7 @@
 'use strict';
 
 angular
-    .module('adminApp', [
+    .module('RoaveDeveloperToolsAdmin', [
         'ngResource',
         'ngRoute'
     ])

--- a/admin/app/scripts/app.js
+++ b/admin/app/scripts/app.js
@@ -5,7 +5,7 @@ angular
         'ngResource',
         'ngRoute'
     ])
-    .config(function ($routeProvider) {
+    .config(['$routeProvider', '$provide', function ($routeProvider, $provide) {
         $routeProvider
             .when('/', {
                 templateUrl: 'views/main.html',
@@ -22,4 +22,11 @@ angular
             .otherwise({
                 redirectTo: '/'
             });
-    });
+
+        $provide.constant(
+            'RDT_REPORTS',
+            {
+                'base-report': 'views/report/base-report.html'
+            }
+        );
+    }]);

--- a/admin/app/scripts/controller/inspectionCtrl.js
+++ b/admin/app/scripts/controller/inspectionCtrl.js
@@ -1,7 +1,7 @@
 'use strict';
 
 angular
-    .module('adminApp')
+    .module('RoaveDeveloperToolsAdmin')
     .controller('inspectionCtrl', ['$scope', '$routeParams', '$inspectionsRepository', function ($scope, $routeParams, $inspectionsRepository) {
         $scope.inspection = null;
 

--- a/admin/app/scripts/controller/inspectionCtrl.js
+++ b/admin/app/scripts/controller/inspectionCtrl.js
@@ -5,10 +5,12 @@ angular
     .controller(
         'inspectionCtrl',
         ['$scope', '$routeParams', '$inspectionsRepository', 'RDT_REPORTS', function ($scope, $routeParams, $inspectionsRepository, RDT_REPORTS) {
-        $scope.inspection = null;
+        $scope.inspection     = null;
+        $scope.subInspections = null;
 
         $inspectionsRepository.getInspectionById($routeParams.inspectionId).then(function (inspection) {
-            $scope.inspection = inspection;
+            $scope.inspection     = inspection;
+            $scope.subInspections = inspection.getSubInspections();
         });
 
         // @todo should be an object, not just an array

--- a/admin/app/scripts/controller/inspectionCtrl.js
+++ b/admin/app/scripts/controller/inspectionCtrl.js
@@ -2,10 +2,15 @@
 
 angular
     .module('RoaveDeveloperToolsAdmin')
-    .controller('inspectionCtrl', ['$scope', '$routeParams', '$inspectionsRepository', function ($scope, $routeParams, $inspectionsRepository) {
+    .controller(
+        'inspectionCtrl',
+        ['$scope', '$routeParams', '$inspectionsRepository', 'RDT_REPORTS', function ($scope, $routeParams, $inspectionsRepository, RDT_REPORTS) {
         $scope.inspection = null;
 
         $inspectionsRepository.getInspectionById($routeParams.inspectionId).then(function (inspection) {
             $scope.inspection = inspection;
         });
+
+        // @todo should be an object, not just an array
+        $scope.reports = RDT_REPORTS;
     }]);

--- a/admin/app/scripts/controller/listInspectionsCtrl.js
+++ b/admin/app/scripts/controller/listInspectionsCtrl.js
@@ -1,7 +1,7 @@
 'use strict';
 
 angular
-    .module('adminApp')
+    .module('RoaveDeveloperToolsAdmin')
     .controller('listInspectionsCtrl', ['$scope', '$inspectionsRepository', function ($scope, $inspectionsRepository) {
         $scope.inspectionIds = [];
 

--- a/admin/app/scripts/controller/main.js
+++ b/admin/app/scripts/controller/main.js
@@ -1,6 +1,6 @@
 'use strict';
 
-angular.module('adminApp')
+angular.module('RoaveDeveloperToolsAdmin')
     .controller('MainCtrl', ['$scope', function ($scope) {
         $scope.awesomeThings = [
             'HTML5 Boilerplate',

--- a/admin/app/scripts/controller/report/baseReportCtrl.js
+++ b/admin/app/scripts/controller/report/baseReportCtrl.js
@@ -1,0 +1,5 @@
+'use strict';
+
+angular
+    .module('RoaveDeveloperToolsAdmin')
+    .controller('baseReportCtrl', function () {});

--- a/admin/app/scripts/entity/Inspection.js
+++ b/admin/app/scripts/entity/Inspection.js
@@ -6,5 +6,29 @@
         this.data = data;
     }
 
+    Inspection.prototype = {
+        getType: function () {
+            return this.data.inspectionType;
+        },
+
+        getSubInspections: function () {
+            var inspectionData = this.data.inspectionData,
+                idx = 0,
+                id = this.id;
+
+            if (!Array.isArray(inspectionData)) {
+                return [];
+            }
+
+            return inspectionData.map(function (inspection) {
+                return new Inspection(id + '-' + (idx += 1), inspection);
+            });
+        },
+
+        getData: function () {
+            return this.data.inspectionData;
+        }
+    };
+
     exports.Inspection = Inspection;
 }(window));

--- a/admin/app/scripts/service/$inspectionsRepository.js
+++ b/admin/app/scripts/service/$inspectionsRepository.js
@@ -3,7 +3,7 @@
 var InspectionsRepository = InspectionsRepository || function Inspection () {};
 
 angular
-    .module('adminApp')
+    .module('RoaveDeveloperToolsAdmin')
     .factory('$inspectionsRepository', ['$http', function ($http) {
         return new InspectionsRepository($http);
     }]);

--- a/admin/app/views/inspection.html
+++ b/admin/app/views/inspection.html
@@ -10,6 +10,11 @@
     <p class="lead">Inspection <code>{{ inspection.id }}</code>:</p>
 </div>
 
+<div ng-repeat="report in reports">
+    <h3>Report {{ report }}</h3>
+    <div ng-include="report"></div>
+</div>
+
 <div class="footer">
     <p><span class="glyphicon glyphicon-heart"></span> from the <a href="https://roave.com/">Roave</a> team</p>
 </div>

--- a/admin/app/views/inspection.html
+++ b/admin/app/views/inspection.html
@@ -10,9 +10,11 @@
     <p class="lead">Inspection <code>{{ inspection.id }}</code>:</p>
 </div>
 
-<div ng-repeat="report in reports">
-    <h3>Report {{ report }}</h3>
-    <div ng-include="report"></div>
+<div ng-repeat="reportInspection in subInspections">
+    <div ng-repeat="report in reports">
+        <h3>Report {{ report }}</h3>
+        <div ng-include="report"></div>
+    </div>
 </div>
 
 <div class="footer">

--- a/admin/app/views/report/base-report.html
+++ b/admin/app/views/report/base-report.html
@@ -1,0 +1,10 @@
+<div ng-controller="baseReportCtrl">
+    <dl>
+        <dt>Inspection ID</dt>
+        <dd>{{ reportInspection.id }}</dd>
+        <dt>Inspection type</dt>
+        <dd>{{ reportInspection.getType() }}</dd>
+        <dt>Inspection data</dt>
+        <dd>{{ reportInspection.getData() }}</dd>
+    </dl>
+</div>

--- a/admin/app/views/report/base-report.html
+++ b/admin/app/views/report/base-report.html
@@ -4,7 +4,5 @@
         <dd>{{ reportInspection.id }}</dd>
         <dt>Inspection type</dt>
         <dd>{{ reportInspection.getType() }}</dd>
-        <dt>Inspection data</dt>
-        <dd>{{ reportInspection.getData() }}</dd>
     </dl>
 </div>

--- a/admin/app/views/report/base-report.html
+++ b/admin/app/views/report/base-report.html
@@ -4,5 +4,7 @@
         <dd>{{ reportInspection.id }}</dd>
         <dt>Inspection type</dt>
         <dd>{{ reportInspection.getType() }}</dd>
+        <dt>Inspection data</dt>
+        <dd><input type="text" value="{{ reportInspection.getData() }}"/></dd>
     </dl>
 </div>

--- a/admin/app/views/report/config-report.html
+++ b/admin/app/views/report/config-report.html
@@ -1,0 +1,4 @@
+<div ng-if="'Roave\\DeveloperTools\\Mvc\\Inspection\\ConfigInspection' == reportInspection.getType()">
+    <h3>Configuration:</h3>
+    <pre pretty-json="reportInspection.getData()"/>
+</div>

--- a/admin/app/views/report/dummy-report.html
+++ b/admin/app/views/report/dummy-report.html
@@ -1,0 +1,6 @@
+<div ng-controller="baseReportCtrl">
+    <dl>
+        <dt>Dummy report data:</dt>
+        <dd>{{ reportInspection.getData() }}</dd>
+    </dl>
+</div>

--- a/admin/bower.json
+++ b/admin/bower.json
@@ -8,7 +8,8 @@
         "jquery": "~1.11.0",
         "bootstrap-sass-official": "~3.1.0",
         "angular-resource": "1.2.15",
-        "angular-route": "1.2.15"
+        "angular-route": "1.2.15",
+        "ng-prettyjson": "0.1.1"
     },
     "devDependencies": {
         "angular-mocks": "1.2.15",

--- a/admin/bower.json
+++ b/admin/bower.json
@@ -9,7 +9,7 @@
         "bootstrap-sass-official": "~3.1.0",
         "angular-resource": "1.2.15",
         "angular-route": "1.2.15",
-        "ng-prettyjson": "0.1.1"
+        "ng-prettyjson": "master"
     },
     "devDependencies": {
         "angular-mocks": "1.2.15",

--- a/admin/karma.conf.js
+++ b/admin/karma.conf.js
@@ -17,6 +17,7 @@ module.exports = function (config) {
             'app/bower_components/angular-cookies/angular-cookies.js',
             'app/bower_components/angular-sanitize/angular-sanitize.js',
             'app/bower_components/angular-route/angular-route.js',
+            'app/bower_components/ng-prettyjson/src/ng-prettyjson.js',
             'app/scripts/*.js',
             'app/scripts/**/*.js',
             'test/mock/**/*.js',

--- a/admin/test/spec/controllers/inspectionCtrl.js
+++ b/admin/test/spec/controllers/inspectionCtrl.js
@@ -20,14 +20,15 @@ describe('Controller: inspectionCtrl', function () {
                     then: function (cb) {
                         cb(new Inspection(id, {'foo': 'bar'}));
                     }
-                }
+                };
             }
         };
 
         inspectionCtrl = $controller('inspectionCtrl', {
             $scope: scope,
             $routeParams: {inspectionId: 123},
-            $inspectionsRepository: $inspectionsRepository
+            $inspectionsRepository: $inspectionsRepository,
+            RDT_REPORTS: {'report-name': 'report/script/path.html'}
         });
     }));
 
@@ -35,5 +36,9 @@ describe('Controller: inspectionCtrl', function () {
         expect(scope.inspection instanceof Inspection).toBeTruthy();
         expect(scope.inspection.id).toBe(123);
         expect(scope.inspection.data.foo).toBe('bar');
+    });
+
+    it('should load the reports map in the scope', function () {
+        expect(scope.reports).toEqual({'report-name': 'report/script/path.html'});
     });
 });

--- a/admin/test/spec/controllers/inspectionCtrl.js
+++ b/admin/test/spec/controllers/inspectionCtrl.js
@@ -41,4 +41,8 @@ describe('Controller: inspectionCtrl', function () {
     it('should load the reports map in the scope', function () {
         expect(scope.reports).toEqual({'report-name': 'report/script/path.html'});
     });
+
+    it('should load the current inspection\'s sub-inspections in the scope', function () {
+        expect(Array.isArray(scope.subInspections)).toBeTruthy();
+    });
 });

--- a/admin/test/spec/controllers/inspectionCtrl.js
+++ b/admin/test/spec/controllers/inspectionCtrl.js
@@ -3,7 +3,7 @@
 describe('Controller: inspectionCtrl', function () {
 
     // load the controller's module
-    beforeEach(module('adminApp'));
+    beforeEach(module('RoaveDeveloperToolsAdmin'));
 
     var inspectionCtrl,
         scope;

--- a/admin/test/spec/controllers/listInspectionsCtrl.js
+++ b/admin/test/spec/controllers/listInspectionsCtrl.js
@@ -3,7 +3,7 @@
 describe('Controller: listInspectionsCtrl', function () {
 
     // load the controller's module
-    beforeEach(module('adminApp'));
+    beforeEach(module('RoaveDeveloperToolsAdmin'));
 
     var listInspectionsCtrl,
         scope;

--- a/admin/test/spec/controllers/listInspectionsCtrl.js
+++ b/admin/test/spec/controllers/listInspectionsCtrl.js
@@ -20,7 +20,7 @@ describe('Controller: listInspectionsCtrl', function () {
                     then: function (cb) {
                         cb(['aa', 'bb', 'cc']);
                     }
-                }
+                };
             }
         };
 
@@ -31,9 +31,6 @@ describe('Controller: listInspectionsCtrl', function () {
     }));
 
     it('should put the inspections identifiers in the current view', function () {
-        expect(scope.inspectionIds.length).toBe(3);
-        expect(scope.inspectionIds[0]).toBe('aa');
-        expect(scope.inspectionIds[1]).toBe('bb');
-        expect(scope.inspectionIds[2]).toBe('cc');
+        expect(scope.inspectionIds).toEqual(['aa', 'bb', 'cc']);
     });
 });

--- a/admin/test/spec/controllers/main.js
+++ b/admin/test/spec/controllers/main.js
@@ -3,7 +3,7 @@
 describe('Controller: MainCtrl', function () {
 
     // load the controller's module
-    beforeEach(module('adminApp'));
+    beforeEach(module('RoaveDeveloperToolsAdmin'));
 
     var MainCtrl,
         scope;

--- a/admin/test/spec/entity/Inspection.js
+++ b/admin/test/spec/entity/Inspection.js
@@ -1,0 +1,33 @@
+'use strict';
+
+describe('Entity: Inspection', function () {
+    it('should have a set identifier', function () {
+        expect((new Inspection(123, {})).id).toBe(123);
+    });
+
+    it('should have a set string identifier', function () {
+        expect((new Inspection('abc', {})).id).toBe('abc');
+    });
+
+    it('should have a inspection data', function () {
+        expect((new Inspection(123, {inspectionData: {foo: 'bar'}})).getData()).toEqual({foo: 'bar'});
+    });
+
+    it('should always have sub-inspections', function () {
+        expect((new Inspection(123, {})).getSubInspections()).toEqual([]);
+    });
+
+    it('should have sub-inspections if they are an array', function () {
+        expect((new Inspection(123, {inspectionData: ['a', 'b', 'c']}))
+            .getSubInspections())
+            .toEqual([
+                new Inspection('123-1', 'a'),
+                new Inspection('123-2', 'b'),
+                new Inspection('123-3', 'c')
+            ]);
+    });
+
+    it('should have sub-inspections if they are an array', function () {
+        expect((new Inspection(123, {inspectionData: {foo: 'bar'}})).getSubInspections()).toEqual([]);
+    });
+});


### PR DESCRIPTION
This PR introduces modular report views.

For now, it is just an array of views registered as constant in the `RoaveDeveloperToolsAdmin` module under the angular constant `RDT_REPORTS`.

The idea is simple: for each inspection, cycle through all the available reports and see if any data can be rendered.

If not, skip (see `views/report/config-report.html`)

Ping @archSeer 

![Preview](http://marco-pivetta.com/screen/caps/5e1b5b.png)
